### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,13 @@ val url: String = TestEnvironment.url("service") + "/path"
 See an [example](https://github.com/hmrc/platform-example-api-scalatest-tests/blob/main/src/test/scala/uk/gov/hmrc/api/service/IndividualsMatchingService.scala).
 
 
-### API Logger
-
-An API logger is available. 
-
-Use the logger as follows:
+### Log info to help debug test failures
 
 ```scala
+import uk.gov.hmrc.api.utils.ApiLogger.logger
+
 logger.info("Log a message")
 ```
-
-See an [example](https://github.com/hmrc/platform-example-api-scalatest-tests/blob/main/src/test/scala/uk/gov/hmrc/api/client/HttpClient.scala).
 
 ## Development
 


### PR DESCRIPTION
Tweaked the logger section of the readme because I noticed the link was broken and it didn't show how to import it

Bit devils advocate - but might be something that people will ask, if people are writing tests where logs will be thrown away, what's the benefit of the logger over just using `println("Log a message")` (and should we describe that in the readme to encourage it's use - for example, will logs logged this way appear in test reports or anything like that?)

I also reworded it a bit because I think "ApiLogger" is a bit abstract in itself of what it's intent is for use in tests