### PR TITLE
PLATUI-3312 - Update library dependencies for Scala 3. Bump Scala Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ lazy val library = (project in file("."))
   .settings(
     name := "api-test-runner",
     majorVersion := 0,
-    scalaVersion := "2.13.13",
-    crossScalaVersions := Seq("2.13.13", "3.3.3"),
+    scalaVersion := "2.13.14",
+    crossScalaVersions := Seq("2.13.14", "3.3.3"),
     isPublicArtefact := true,
     libraryDependencies ++= Dependencies.compile
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,8 @@ object Dependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "com.typesafe"         % "config"                  % "1.4.3",
-    "com.typesafe.play"   %% "play-ahc-ws-standalone"  % "2.2.9",
-    "com.typesafe.play"   %% "play-ws-standalone-json" % "2.2.9",
+    "org.playframework"   %% "play-ahc-ws-standalone"  % "3.0.5",
+    "org.playframework"   %% "play-ws-standalone-json" % "3.0.5",
     "com.vladsch.flexmark" % "flexmark-all"            % "0.64.8",
     "org.scalatest"       %% "scalatest"               % "3.2.19",
     "org.slf4j"            % "slf4j-simple"            % "2.0.13"


### PR DESCRIPTION
this change starts cross building for scala 3 and updates to play-3 versions of play-json and play-ws

when users bump to this version they might have to update any `akka` package imports to `org.apache.pekko`

if their tests repos are using `StandaloneWSRequest#Self#Response` then they will need to refactor to use `StandaloneWSResponse` instead, an example of which can be seen in the [hmrc/platform-example-api-scalatest-tests](https://github.com/hmrc/platform-example-api-scalatest-tests/pull/20) repository
